### PR TITLE
Dockerize 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:2.7
+
+MAINTAINER j nazario <jose@monkey.org>
+
+RUN apt-get -qq update && \
+    apt-get install -yq  libpcap-dev && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENTRYPOINT [ "python", "nosqlframework.py"]
+CMD ["-h"]


### PR DESCRIPTION
allows you to run this from a container. takes args to the container, too, example:

```
Nosql-Exploitation-Framework % docker run -it bb49757059da -ip localhost -scan
[+] localhost is up!

[!] Scanning Module For NoSQL Framework Launched.....

[-] MongoDB port open on localhost:27017!

[-] CouchDB port closed.

[-] RedisDB Port Closed
```